### PR TITLE
Dm 39 salvar usuario em contexto

### DIFF
--- a/src/core-layer/user-module/entities/User.ts
+++ b/src/core-layer/user-module/entities/User.ts
@@ -1,0 +1,11 @@
+export type User = {
+  id: string;
+  email: string;
+  name: string;
+  age: number;
+  state: string;
+  city: string;
+  address: string;
+  phone: string;
+  imageUri: string;
+};

--- a/src/core-layer/user-module/use-cases/LoginUsecase.ts
+++ b/src/core-layer/user-module/use-cases/LoginUsecase.ts
@@ -1,6 +1,10 @@
+import { User } from "../entities/User";
+
 export interface LoginUsecase {
   loginWithPassword(param: {
     username: string;
     password: string;
-  }): Promise<{ type: "success" } | { type: "error"; error: string }>;
+  }): Promise<
+    { type: "success"; user: User } | { type: "error"; error: string }
+  >;
 }

--- a/src/gateway-layer/firebase-module/user-module/gates/utils/UserBuilder.ts
+++ b/src/gateway-layer/firebase-module/user-module/gates/utils/UserBuilder.ts
@@ -1,0 +1,23 @@
+import { FirebaseStorage, getDownloadURL, ref } from "firebase/storage";
+import { User } from "../../../../../core-layer/user-module/entities/User";
+import { UserData } from "../../dto/UserData";
+
+export class UserBuilder {
+  constructor(private firebaseStorage: FirebaseStorage) {}
+
+  async buildUserFromData(data: UserData): Promise<User> {
+    const imageRef = ref(this.firebaseStorage, `users/image/${data.id}`);
+    const imageUri = await getDownloadURL(imageRef);
+    return {
+      id: data.id,
+      email: data.email,
+      name: data.name,
+      age: data.age,
+      state: data.state,
+      city: data.city,
+      address: data.address,
+      phone: data.phone,
+      imageUri,
+    };
+  }
+}

--- a/src/gateway-layer/firebase-module/user-module/index.ts
+++ b/src/gateway-layer/firebase-module/user-module/index.ts
@@ -3,6 +3,7 @@ import { Firestore } from "firebase/firestore";
 import { SignUpGate } from "./gates/SignUpGate";
 import { LoginGate } from "./gates/LoginGate";
 import { FirebaseStorage } from "firebase/storage";
+import { UserBuilder } from "./gates/utils/UserBuilder";
 
 export class FirebaseUserModule {
   signUpGate: SignUpGate;
@@ -13,7 +14,8 @@ export class FirebaseUserModule {
     firebaseDb: Firestore,
     firebaseStorage: FirebaseStorage
   ) {
+    const userBuilder = new UserBuilder(firebaseStorage);
     this.signUpGate = new SignUpGate(firebaseAuth, firebaseDb, firebaseStorage);
-    this.loginGate = new LoginGate(firebaseAuth);
+    this.loginGate = new LoginGate(firebaseAuth, firebaseDb, userBuilder);
   }
 }

--- a/src/view-layer/App/App.tsx
+++ b/src/view-layer/App/App.tsx
@@ -2,11 +2,11 @@ import { SafeAreaView, ScrollView } from "react-native";
 import { CoreLayer } from "../../core-layer";
 import { CoreLayerProvider } from "../contexts/CoreLayerContext";
 import { ThemeProvider } from "../contexts/ThemeContext";
-// import { LoginScreen } from "../screens";
+import { LoginScreen } from "../screens";
 import { StyleSheet } from "react-native";
-import { RegisterAnimalScreen } from "../screens/registerAnimal";
+// import { RegisterAnimalScreen } from "../screens/registerAnimal";
 // import { IntroductionScreen } from "../screens/introduction";
-// import { SignUpScreen } from "../screens/register";
+import { SignUpScreen } from "../screens/register";
 // import { OopsScreen } from "../screens/requireLogin/oopsScreen";
 
 export type AppProps = {
@@ -19,12 +19,12 @@ export function App({ coreLayer }: AppProps) {
       <ThemeProvider>
         <SafeAreaView style={styles.safeArea}>
           <ScrollView>
+            <SignUpScreen />
+            <LoginScreen />
             {/* <OopsScreen /> */}
             {/* <IntroductionScreen /> */}
-            {/* <LoginScreen /> */}
             {/* <SignUpScreen /> */}
-            <RegisterAnimalScreen />
-            {/* <SignUpScreen /> */}
+            {/* <RegisterAnimalScreen /> */}
           </ScrollView>
         </SafeAreaView>
       </ThemeProvider>

--- a/src/view-layer/App/App.tsx
+++ b/src/view-layer/App/App.tsx
@@ -1,6 +1,7 @@
 import { SafeAreaView, ScrollView } from "react-native";
 import { CoreLayer } from "../../core-layer";
 import { CoreLayerProvider } from "../contexts/CoreLayerContext";
+import { UserProvider } from "../contexts/UserContext";
 import { ThemeProvider } from "../contexts/ThemeContext";
 import { LoginScreen } from "../screens";
 import { StyleSheet } from "react-native";
@@ -16,18 +17,20 @@ export type AppProps = {
 export function App({ coreLayer }: AppProps) {
   return (
     <CoreLayerProvider coreLayer={coreLayer}>
-      <ThemeProvider>
-        <SafeAreaView style={styles.safeArea}>
-          <ScrollView>
-            <SignUpScreen />
-            <LoginScreen />
-            {/* <OopsScreen /> */}
-            {/* <IntroductionScreen /> */}
-            {/* <SignUpScreen /> */}
-            {/* <RegisterAnimalScreen /> */}
-          </ScrollView>
-        </SafeAreaView>
-      </ThemeProvider>
+      <UserProvider>
+        <ThemeProvider>
+          <SafeAreaView style={styles.safeArea}>
+            <ScrollView>
+              <SignUpScreen />
+              <LoginScreen />
+              {/* <OopsScreen /> */}
+              {/* <IntroductionScreen /> */}
+              {/* <SignUpScreen /> */}
+              {/* <RegisterAnimalScreen /> */}
+            </ScrollView>
+          </SafeAreaView>
+        </ThemeProvider>
+      </UserProvider>
     </CoreLayerProvider>
   );
 }

--- a/src/view-layer/contexts/UserContext.tsx
+++ b/src/view-layer/contexts/UserContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, PropsWithChildren, useContext, useState } from "react";
+import { User } from "../../core-layer/user-module/entities/User";
+
+type UserContextValue = {
+  user: null | User;
+  setUser: (user: null | User) => void;
+};
+
+const UserContext = createContext<UserContextValue>({} as UserContextValue);
+
+export function UserProvider({ children }: PropsWithChildren) {
+  const [user, setUser] = useState<null | User>(null);
+
+  return (
+    <UserContext.Provider value={{ user, setUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export function useUserContext() {
+  return useContext(UserContext);
+}

--- a/src/view-layer/screens/register/LoginScreen.tsx
+++ b/src/view-layer/screens/register/LoginScreen.tsx
@@ -4,6 +4,7 @@ import { Appbar } from "../../shared/components/Appbar";
 import { Formik } from "formik";
 import { useCallback, useState } from "react";
 import { useCoreLayer } from "../../contexts/CoreLayerContext";
+import { useUserContext } from "../../contexts/UserContext";
 
 type LoginFormValue = {
   username: string;
@@ -17,6 +18,7 @@ const initialValues: LoginFormValue = {
 
 export function LoginScreen() {
   const theme = useTheme();
+  const { setUser } = useUserContext();
 
   const [snackMessage, setSnackMessage] = useState(null as string | null);
 
@@ -29,10 +31,14 @@ export function LoginScreen() {
         password: formValue.password,
         username: formValue.username,
       });
-      if (result.type === "error") setSnackMessage("Erro");
-      else setSnackMessage("Sucesso");
+      if (result.type === "error") {
+        setSnackMessage("Erro");
+        return;
+      }
+      setUser(result.user);
+      setSnackMessage("Sucesso");
     },
-    [loginUsecase]
+    [loginUsecase, setUser]
   );
 
   return (


### PR DESCRIPTION
## Descrição

<!-- Link para a issue no Jira -->
Issue: [DM-39](https://luigiminardim.atlassian.net/browse/DM-39)

<!-- Descrição de como a issue foi resolvida -->
Ao fazer o login, a estrutura de usuário é retornada do LoginUsecase e salva em um novo contexto chamado UserContext.

## Evidências

É difícil ter evidências nessa tarefa.

## Teste

- [x] Faça o signup na tela de SignUpScreen, crie um novo usuário com algum e-mail que não exista na base de dados Firebase Auth.
- [x] Faça o login na tela LoginScreen e verifique que o usuário foi criado com sucesso.
- Neste momento, o usuário deve estar salvo no no contexto de usuário e acessível pelo hook `useUserContext()`;


[DM-39]: https://luigiminardim.atlassian.net/browse/DM-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ